### PR TITLE
Merge CI Build Actions to production

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,0 +1,27 @@
+name: Makefile CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: configure
+      run: ./configure
+
+    - name: Install dependencies
+      run: make
+
+    - name: Run check
+      run: make check
+
+    - name: Run distcheck
+      run: make distcheck

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -14,9 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: configure
-      run: ./configure
-
     - name: Install dependencies
       run: make
 

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -16,9 +16,3 @@ jobs:
 
     - name: Install dependencies
       run: make
-
-    - name: Run check
-      run: make check
-
-    - name: Run distcheck
-      run: make distcheck


### PR DESCRIPTION
For automated testing and building, I want to move the base CI into main and leave it there until any big changes are done to it.